### PR TITLE
Enable options extra and lto for COMP=mingw, too.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -281,7 +281,7 @@ ifeq ($(optimize),yes)
 
 	CFLAGS += -O3
 
-	ifeq ($(comp),gcc)
+	ifeq ($(comp),$(filter $(comp),gcc mingw))
 		ifeq ($(extra),yes)
 			CFLAGS += -fira-loop-pressure -fconserve-stack -fmodulo-sched -fmodulo-sched-allow-regmoves -fsched-pressure -flimit-function-alignment
 		endif
@@ -351,16 +351,9 @@ endif
 ifeq ($(lto),yes)
 ifeq ($(optimize),yes)
 ifeq ($(debug),no)
-	ifeq ($(comp),$(filter $(comp),gcc clang))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
 		CFLAGS += -flto
 		LDFLAGS += $(CFLAGS)
-	endif
-
-	ifeq ($(comp),mingw)
-	ifeq ($(KERNEL),Linux)
-		CFLAGS += -flto
-		LDFLAGS += $(CFLAGS)
-	endif
 	endif
 endif
 endif


### PR DESCRIPTION
I do not see a good reason to disallow lto=yes and extra=yes for build with COMP=mingw.
For me all (Windows 10, msys2) variants work (enabling both, enabling only one of it).