### PR TITLE
Make GitHub Linguist show .h files as C language.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.h linguist-language=C


### PR DESCRIPTION
Currently GitHub shows .h files as C++ language. This commit sets a `linguist-language` override to force GitHub Linguist to show these files as C language.