### PR TITLE
Changes for C++ mode compilation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -154,8 +154,7 @@ endif
 
 ### 3.1 Selecting compiler (default = gcc)
 
-CFLAGS += -Wall -std=c11 $(EXTRACFLAGS)
-DEPENDFLAGS += -std=c11
+CFLAGS += -Wall $(EXTRACFLAGS)
 LDFLAGS += $(EXTRALDFLAGS) -lm
 
 ifeq ($(COMP),)
@@ -229,8 +228,8 @@ ifeq ($(COMP),clang)
 	endif
 
 	ifeq ($(KERNEL),Darwin)
-		CFLAGS += 
-		DEPENDFLAGS += 
+		CFLAGS +=
+		DEPENDFLAGS +=
 	endif
 endif
 
@@ -376,6 +375,21 @@ ifeq ($(arch),armv7)
 	LDFLAGS += -fPIE -pie
 endif
 
+ifeq ($(LANG), c++)
+	lang=c++
+	ifeq ($(COMP),gcc)
+		CFLAGS += -x c++ -std=c++11 -Wno-pedantic -Wno-extra -Wno-write-strings -Wno-class-memaccess
+		DEPENDFLAGS += -std=c++11
+	else ifeq ($(COMP),clang)
+		CFLAGS += -x c++ -std=c++11 -Wno-gnu-anonymous-struct -Wno-c99-extensions -Wno-vla-extension -Wno-nested-anon-types -Wno-write-strings
+		DEPENDFLAGS += -std=c++11
+	endif
+else
+	lang=c
+	CFLAGS += -std=c11
+	DEPENDFLAGS += -std=c11
+endif
+
 
 ### ==========================================================================
 ### Section 4. Public targets
@@ -492,6 +506,7 @@ config-sanity:
 	@echo "CC: $(CC)"
 	@echo "CFLAGS: $(CFLAGS)"
 	@echo "LDFLAGS: $(LDFLAGS)"
+	@echo "LANG: $(LANG)"
 	@echo ""
 	@echo "Testing config sanity. If this fails, try 'make help' ..."
 	@echo ""
@@ -506,6 +521,7 @@ config-sanity:
 	@test "$(pext)" = "yes" || test "$(pext)" = "no"
 	@test "$(lto)" = "yes" || test "$(lto)" = "no"
 	@test "$(comp)" = "gcc" || test "$(comp)" = "icc" || test "$(comp)" = "mingw" || test "$(comp)" = "clang"
+	@test "$(lang)" = "c" || (test "$(lang)" = "c++" && (test "$(comp)" = "gcc" || test "$(comp)" = "clang"))
 
 $(EXE): $(OBJS)
 	$(CC) -o $@ $(OBJS) $(LDFLAGS)
@@ -549,4 +565,3 @@ icc-profile-use:
 	-@$(CC) $(DEPENDFLAGS) -MM $(OBJS:.o=.c) > $@ 2> /dev/null
 
 -include .depend
-

--- a/src/benchmark.c
+++ b/src/benchmark.c
@@ -109,7 +109,7 @@ void benchmark(Pos *current, char *str)
   int threads     = (token = strtok(NULL, " ")) ? atoi(token)  : 1;
   int64_t limit   = (token = strtok(NULL, " ")) ? atoll(token) : 13;
   char *fenFile   = (token = strtok(NULL, " ")) ? token        : NULL;
-  char *limitType = (token = strtok(NULL, " ")) ? token        : "";
+  char *limitType = (token = strtok(NULL, " ")) ? token        : (char*)"";
 
   delayedSettings.ttSize = ttSize;
   delayedSettings.numThreads = threads;
@@ -130,8 +130,8 @@ void benchmark(Pos *current, char *str)
     numFens = sizeof(Defaults) / sizeof(char *);
   }
   else if (strcmp(fenFile, "current") == 0) {
-    fens = malloc(sizeof(*fens));
-    fens[0] = malloc(128);
+    fens = (char**) malloc(sizeof(*fens));
+    fens[0] = (char*)malloc(128);
     pos_fen(current, fens[0]);
     numFens = 1;
   }
@@ -143,14 +143,14 @@ void benchmark(Pos *current, char *str)
       fprintf(stderr, "Unable to open file %s\n", fenFile);
       return;
     }
-    fens = malloc(maxFens * sizeof(*fens));
+    fens = (char**)malloc(maxFens * sizeof(*fens));
     fens[0] = NULL;
     size_t length = 0;
     while (getline(&fens[numFens], &length, F) > 0) {
       numFens++;
       if (numFens == maxFens) {
         maxFens += 100;
-        fens = realloc(fens, maxFens * sizeof(*fens));
+        fens = (char**)realloc(fens, maxFens * sizeof(*fens));
       }
       fens[numFens] = NULL;
       length = 0;
@@ -160,9 +160,9 @@ void benchmark(Pos *current, char *str)
 
   uint64_t nodes = 0;
   Pos pos;
-  pos.stack = malloc(215 * sizeof(*pos.stack));
+  pos.stack = (Stack*) malloc(215 * sizeof(*pos.stack));
   pos.st = pos.stack + 5;
-  pos.moveList = malloc(10000 * sizeof(*pos.moveList));
+  pos.moveList = (ExtMove*) malloc(10000 * sizeof(*pos.moveList));
   TimePoint elapsed = now();
 
   int numOpts = 0;

--- a/src/bitbase.c
+++ b/src/bitbase.c
@@ -54,7 +54,7 @@ unsigned bitbases_probe(Square wksq, Square wpsq, Square bksq, unsigned us)
   return KPKBitbase[idx / 32] & (1 << (idx & 0x1F));
 }
 
-static uint8_t initial(unsigned idx)
+static uint8_t initial(int idx)
 {
   int ksq[2] = { (idx >> 0) & 0x3f, (idx >> 6) & 0x3f };
   int us     = (idx >> 12) & 0x01;
@@ -85,7 +85,7 @@ static uint8_t initial(unsigned idx)
   return RES_UNKNOWN;
 }
 
-static uint8_t classify(uint8_t *db, unsigned idx)
+static uint8_t classify(uint8_t *db, int idx)
 {
   int ksq[2] = { (idx >> 0) & 0x3f, (idx >> 6) & 0x3f };
   int us     = (idx >> 12) & 0x01;
@@ -127,7 +127,7 @@ static uint8_t classify(uint8_t *db, unsigned idx)
 
 void bitbases_init()
 {
-  uint8_t *db = malloc(MAX_INDEX);
+  uint8_t *db = (uint8_t*) malloc(MAX_INDEX);
   unsigned idx, repeat = 1;
 
   // Initialize db with known win / draw positions

--- a/src/material.c
+++ b/src/material.c
@@ -19,7 +19,7 @@
 */
 
 #include <assert.h>
-#include <string.h>   // For std::memset
+#include <string.h>   // For memset
 
 #include "material.h"
 #include "position.h"
@@ -188,7 +188,7 @@ void material_entry_fill(const Pos *pos, MaterialEntry *e, Key key)
   // Evaluate the material imbalance. We use PIECE_TYPE_NONE as a place
   // holder for the bishop pair "extended piece", which allows us to be
   // more flexible in defining bishop pair bonuses.
-#define pc(c,p) piece_count_mk(c,p)
+#define pc(c,p) (int)piece_count_mk(c,p)
   int PieceCount[2][8] = {
     { pc(0, BISHOP) > 1, pc(0, PAWN), pc(0, KNIGHT),
       pc(0, BISHOP)    , pc(0, ROOK), pc(0, QUEEN) },

--- a/src/misc.c
+++ b/src/misc.c
@@ -119,22 +119,24 @@ uint64_t prng_sparse_rand(PRNG *rng)
   return r1 & r2 & r3;
 }
 
+#if !defined(__cplusplus)
 ssize_t getline(char **lineptr, size_t *n, FILE *stream)
 {
   if (*n == 0)
-    *lineptr = malloc(*n = 100);
+     *lineptr = (char*) malloc(*n = 100);
 
   int c = 0;
   size_t i = 0;
   while ((c = getc(stream)) != EOF) {
     (*lineptr)[i++] = c;
     if (i == *n)
-      *lineptr = realloc(*lineptr, *n += 100);
+	    *lineptr = (char*) realloc(*lineptr, *n += 100);
     if (c == '\n') break;
   }
   (*lineptr)[i] = 0;
   return i;
 }
+#endif
 
 #ifdef _WIN32
 typedef SIZE_T (WINAPI *GLPM)(void);

--- a/src/misc.h
+++ b/src/misc.h
@@ -26,7 +26,6 @@
 #ifndef _WIN32
 #include <pthread.h>
 #endif
-#include <stdatomic.h>
 #include <sys/time.h>
 #include <unistd.h>
 

--- a/src/ntsearch.c
+++ b/src/ntsearch.c
@@ -71,12 +71,12 @@ Value search_NonPV(Pos *pos, Stack *ss, Value alpha, Depth depth, int cutNode)
 
   // Check for the available remaining time
   if (load_rlx(pos->resetCalls)) {
-    store_rlx(pos->resetCalls, 0);
+    store_rlx(pos->resetCalls, false);
     pos->callsCnt = Limits.nodes ? min(1024, Limits.nodes / 1024) : 1024;
   }
   if (--pos->callsCnt <= 0) {
     for (int idx = 0; idx < Threads.numThreads; idx++)
-      store_rlx(Threads.pos[idx]->resetCalls, 1);
+      store_rlx(Threads.pos[idx]->resetCalls, true);
 
     check_time();
   }

--- a/src/numa.c
+++ b/src/numa.c
@@ -40,8 +40,8 @@ void numa_init(void)
   delayedSettings.mask = numa_allocate_nodemask();
 
   // Determine number of logical and physical cores per node
-  numPhysicalCores = malloc(numNodes * sizeof(int));
-  nodeMask = malloc(numNodes * sizeof(struct bitmask *));
+  numPhysicalCores = (int*)malloc(numNodes * sizeof(int));
+  nodeMask = (struct bitmask**)malloc(numNodes * sizeof(struct bitmask *));
   struct bitmask *cpuMask = numa_allocate_cpumask();
   int numCpus = numa_num_configured_cpus();
   char name[96];
@@ -176,7 +176,7 @@ void numa_init(void)
   numNodes = 0;
   int maxNodes = 16;
   nodeNumber = malloc(maxNodes * sizeof(int));
-  
+
   DWORD len = 0;
   DWORD offset = 0;
 
@@ -227,7 +227,7 @@ void numa_init(void)
         numNodes++;
       }
       offset += ptr->Size;
-      ptr = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *)(((char *)ptr) + ptr->Size);        
+      ptr = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *)(((char *)ptr) + ptr->Size);
     }
 
     // Then count cores in each node
@@ -244,7 +244,7 @@ void numa_init(void)
             numPhysicalCores[i]++;
       }
       offset += ptr->Size;
-      ptr = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)(((char*)ptr) + ptr->Size);        
+      ptr = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)(((char*)ptr) + ptr->Size);
     }
     free(buffer);
 

--- a/src/polybook.c
+++ b/src/polybook.c
@@ -342,7 +342,7 @@ void pb_init(const char *bookfile)
   FD fd = open_file(bookfile);
   if (fd != FD_ERR) {
     keycount = file_size(fd) / 16;
-    polyhash = map_file(fd, &mapping);
+    polyhash = (struct PolyHash*) map_file(fd, &mapping);
   }
   close_file(fd);
 
@@ -376,7 +376,7 @@ Move pb_probe(Pos *pos)
   Move m1 = 0;
 
   if (!enabled) return m1;
-  if (!check_do_search(pos)) return m1;   
+  if (!check_do_search(pos)) return m1;
 
   if (book_depth_count >= max_book_depth)
     return m1;
@@ -460,7 +460,7 @@ static Key polyglot_key(const Pos *pos)
 // move is a promotion we have to convert to our representation, in all the
 // other cases we can directly compare with a Move after having masked out
 // the special Move's flags (bit 14-15) that are not supported by PolyGlot.
-// 
+//
 // SF:
 // bit  0- 5: destination square (from 0 to 63)
 // bit  6-11: origin square (from 0 to 63)

--- a/src/position.c
+++ b/src/position.c
@@ -127,7 +127,7 @@ void print_pos(Pos *pos)
     printf(" |\n +---+---+---+---+---+---+---+---+\n");
   }
 
-  printf("\nFen: %s\nKey: %16"PRIX64"\nCheckers: ", fen, pos_key());
+  printf("\nFen: %s\nKey: %16" PRIX64 "\nCheckers: ", fen, pos_key());
 
   char buf[16];
   for (Bitboard b = pos_checkers(); b; )
@@ -228,7 +228,7 @@ void pos_set(Pos *pos, char *fen, int isChess960)
   Square sq = SQ_A8;
 
   Stack *st = pos->st;
-  memset(pos, 0, offsetof(Pos, moveList));
+  memset((void*)pos, 0, offsetof(Pos, moveList));
   pos->st = st;
   memset(st, 0, StateSize);
 #ifdef PEDANTIC
@@ -913,7 +913,7 @@ void undo_move(Pos *pos, Move m)
   Stack *st = pos->st--;
   pos->sideToMove ^= 1;
   Color us = pos->sideToMove;
- 
+
   if (likely(type_of_m(m) != PROMOTION)) {
     pos->byTypeBB[piece & 7] ^= sq_bb(from) ^ sq_bb(to);
   } else {

--- a/src/position.h
+++ b/src/position.h
@@ -25,9 +25,18 @@
 #ifndef _WIN32
 #include <pthread.h>
 #endif
-#include <stdatomic.h>
 #include <stddef.h>  // For offsetof()
 #include <string.h>
+
+#if defined(__cplusplus)
+#include <atomic>
+using std::atomic_bool;
+using std::memory_order_relaxed;
+using std::memory_order_release;
+using std::memory_order_acquire;
+#else
+#include <stdatomic.h>
+#endif
 
 #include "bitboard.h"
 #include "types.h"

--- a/src/search.c
+++ b/src/search.c
@@ -22,7 +22,7 @@
 #include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
-#include <string.h>   // For std::memset
+#include <string.h>
 
 #include "evaluate.h"
 #include "misc.h"
@@ -218,7 +218,7 @@ uint64_t perft(Pos *pos, Depth depth)
       nodes += cnt;
       undo_move(pos, m->move);
     }
-    printf("%s: %"PRIu64"\n", uci_move(buf, m->move, is_chess960()), cnt);
+    printf("%s: %" PRIu64 "\n", uci_move(buf, m->move, is_chess960()), cnt);
   }
   return nodes;
 }
@@ -373,6 +373,7 @@ void thread_search(Pos *pos)
   Depth lastBestMoveDepth = DEPTH_ZERO;
   double timeReduction = 1.0;
   bool failedLow;
+  int failedHighCnt = 0;
 
   Stack *ss = pos->st; // At least the fifth element of the allocated array.
   for (int i = -5; i < 3; i++)
@@ -475,7 +476,7 @@ void thread_search(Pos *pos)
       // Start with a small aspiration window and, in the case of a fail
       // high/low, re-search with a bigger window until we're not failing
       // high/low anymore.
-      int failedHighCnt = 0;
+      // failedHighCnt = 0;
       while (true) {
         Depth adjustedDepth = max(ONE_PLY, pos->rootDepth - failedHighCnt * ONE_PLY);
         bestValue = search_PV(pos, ss, alpha, beta, adjustedDepth);
@@ -619,9 +620,10 @@ skip_search:
 // qsearch() is the quiescence search function, which is called by the main
 // search function when the remaining depth is zero (or, to be more precise,
 // less than ONE_PLY).
-
+#if !defined (__cplusplus)
 #define true 1
 #define false 0
+#endif
 
 #define NT PV
 #define InCheck false
@@ -853,13 +855,13 @@ static void uci_print_pv(Pos *pos, Depth depth, Value alpha, Value beta)
     if (!tb && i == pvIdx)
       printf("%s", v >= beta ? " lowerbound" : v <= alpha ? " upperbound" : "");
 
-    printf(" nodes %"PRIu64" nps %"PRIu64, nodes_searched,
+    printf(" nodes %" PRIu64 " nps %" PRIu64, nodes_searched,
                               nodes_searched * 1000 / elapsed);
 
     if (elapsed > 1000)
       printf(" hashfull %d", tt_hashfull());
 
-    printf(" tbhits %"PRIu64" time %"PRIi64" pv", tbhits, elapsed);
+    printf(" tbhits %" PRIu64 " time %" PRIi64 " pv", tbhits, elapsed);
 
     for (int idx = 0; idx < rm->move[i].pvSize; idx++)
       printf(" %s", uci_move(buf, rm->move[i].pv[idx], is_chess960()));

--- a/src/tbprobe.h
+++ b/src/tbprobe.h
@@ -17,4 +17,3 @@ int TB_root_probe_dtm(Pos *pos, RootMoves *rm);
 void TB_expand_mate(Pos *pos, RootMove *move);
 
 #endif
-

--- a/src/thread.c
+++ b/src/thread.c
@@ -60,16 +60,16 @@ static THREAD_FUNC thread_init(void *arg)
   if (node >= numCmhTables) {
     int old = numCmhTables;
     numCmhTables = node + 16;
-    cmhTables = realloc(cmhTables,
+    cmhTables = (CounterMoveHistoryStat **) realloc(cmhTables,
         numCmhTables * sizeof(CounterMoveHistoryStat *));
     while (old < numCmhTables)
       cmhTables[old++] = NULL;
   }
   if (!cmhTables[node]) {
     if (settings.numaEnabled)
-      cmhTables[node] = numa_alloc(sizeof(CounterMoveHistoryStat));
+      cmhTables[node] = (CounterMoveHistoryStat*) numa_alloc(sizeof(CounterMoveHistoryStat));
     else
-      cmhTables[node] = calloc(sizeof(CounterMoveHistoryStat), 1);
+      cmhTables[node] = (CounterMoveHistoryStat*) calloc(sizeof(CounterMoveHistoryStat), 1);
     for (int j = 0; j < 16; j++)
       for (int k = 0; k < 64; k++)
         (*cmhTables[node])[0][0][j][k] = CounterMovePruneThreshold - 1;
@@ -78,30 +78,30 @@ static THREAD_FUNC thread_init(void *arg)
   Pos *pos;
 
   if (settings.numaEnabled) {
-    pos = numa_alloc(sizeof(Pos));
-    pos->pawnTable = numa_alloc(PAWN_ENTRIES * sizeof(PawnEntry));
-    pos->materialTable = numa_alloc(8192 * sizeof(MaterialEntry));
-    pos->counterMoves = numa_alloc(sizeof(CounterMoveStat));
-    pos->history = numa_alloc(sizeof(ButterflyHistory));
-    pos->captureHistory = numa_alloc(sizeof(CapturePieceToHistory));
-    pos->rootMoves = numa_alloc(sizeof(RootMoves));
-    pos->stack = numa_alloc((MAX_PLY + 110) * sizeof(Stack));
-    pos->moveList = numa_alloc(10000 * sizeof(ExtMove));
+    pos = (Pos*)numa_alloc(sizeof(Pos));
+    pos->pawnTable = (PawnEntry*)numa_alloc(PAWN_ENTRIES * sizeof(PawnEntry));
+    pos->materialTable = (MaterialEntry*)numa_alloc(8192 * sizeof(MaterialEntry));
+    pos->counterMoves = (CounterMoveStat*)numa_alloc(sizeof(CounterMoveStat));
+    pos->history = (ButterflyHistory*)numa_alloc(sizeof(ButterflyHistory));
+    pos->captureHistory = (CapturePieceToHistory*)numa_alloc(sizeof(CapturePieceToHistory));
+    pos->rootMoves = (RootMoves*)numa_alloc(sizeof(RootMoves));
+    pos->stack = (Stack*)numa_alloc((MAX_PLY + 110) * sizeof(Stack));
+    pos->moveList = (ExtMove*)numa_alloc(10000 * sizeof(ExtMove));
   } else {
-    pos = calloc(sizeof(Pos), 1);
-    pos->pawnTable = calloc(PAWN_ENTRIES * sizeof(PawnEntry), 1);
-    pos->materialTable = calloc(8192 * sizeof(MaterialEntry), 1);
-    pos->counterMoves = calloc(sizeof(CounterMoveStat), 1);
-    pos->history = calloc(sizeof(ButterflyHistory), 1);
-    pos->captureHistory = calloc(sizeof(CapturePieceToHistory), 1);
-    pos->rootMoves = calloc(sizeof(RootMoves), 1);
-    pos->stack = calloc((MAX_PLY + 110) * sizeof(Stack), 1);
-    pos->moveList = calloc(10000 * sizeof(ExtMove), 1);
+    pos = (Pos*)calloc(sizeof(Pos), 1);
+    pos->pawnTable = (PawnEntry*)calloc(PAWN_ENTRIES * sizeof(PawnEntry), 1);
+    pos->materialTable = (MaterialEntry*)calloc(8192 * sizeof(MaterialEntry), 1);
+    pos->counterMoves = (CounterMoveStat*)calloc(sizeof(CounterMoveStat), 1);
+    pos->history = (ButterflyHistory*)calloc(sizeof(ButterflyHistory), 1);
+    pos->captureHistory = (CapturePieceToHistory*)calloc(sizeof(CapturePieceToHistory), 1);
+    pos->rootMoves = (RootMoves*)calloc(sizeof(RootMoves), 1);
+    pos->stack = (Stack*)calloc((MAX_PLY + 110) * sizeof(Stack), 1);
+    pos->moveList = (ExtMove*)calloc(10000 * sizeof(ExtMove), 1);
   }
   pos->threadIdx = idx;
   pos->counterMoveHistory = cmhTables[node];
 
-  atomic_store(&pos->resetCalls, 0);
+  atomic_store(&pos->resetCalls, false);
   pos->selDepth = pos->callsCnt = 0;
 
 #ifndef _WIN32  // linux

--- a/src/thread.h
+++ b/src/thread.h
@@ -21,7 +21,13 @@
 #ifndef THREAD_H
 #define THREAD_H
 
+#ifdef __cplusplus
+#include <atomic>
+using std::atomic_bool;
+#else
 #include <stdatomic.h>
+#endif
+
 #ifndef _WIN32
 #include <pthread.h>
 #else

--- a/src/tt.c
+++ b/src/tt.c
@@ -17,12 +17,13 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-
+#if !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
+#endif
 
 #include <inttypes.h>
 #include <stdio.h>
-#include <string.h>   // For std::memset
+#include <string.h>   // For memset
 #ifndef _WIN32
 #include <sys/mman.h>
 #endif
@@ -139,7 +140,7 @@ void tt_allocate(size_t mbSize)
   return;
 
 failed:
-  fprintf(stderr, "Failed to allocate %"PRIu64"MB for "
+  fprintf(stderr, "Failed to allocate %" PRIu64 "MB for "
                   "transposition table.\n", (uint64_t)mbSize);
   exit(EXIT_FAILURE);
 }

--- a/src/uci.c
+++ b/src/uci.c
@@ -243,8 +243,8 @@ void uci_loop(int argc, char **argv)
   // Slots 0-99 make room for prepending the part of game history relevant
   // for repetition detection.
   // Slots 201-214 may be used by TB root probing.
-  pos.stack = malloc(215 * sizeof(Stack));
-  pos.moveList = malloc(1000 * sizeof(ExtMove));
+  pos.stack = (Stack*) malloc(215 * sizeof(Stack));
+  pos.moveList = (ExtMove*)malloc(1000 * sizeof(ExtMove));
   pos.st = pos.stack + 100;
   pos.st[-1].endMoves = pos.moveList;
 
@@ -254,7 +254,7 @@ void uci_loop(int argc, char **argv)
 
   if (buf_size < 1024) buf_size = 1024;
 
-  char *cmd = malloc(buf_size);
+  char *cmd = (char*)malloc(buf_size);
 
   cmd[0] = 0;
   for (int i = 1; i < argc; i++) {

--- a/src/ucioption.c
+++ b/src/ucioption.c
@@ -167,13 +167,13 @@ void options_init()
     case OPT_TYPE_BUTTON:
       break;
     case OPT_TYPE_STRING:
-      opt->valString = malloc(strlen(opt->defString) + 1);
+      opt->valString = (char*)malloc(strlen(opt->defString) + 1);
       strcpy(opt->valString, opt->defString);
       break;
     case OPT_TYPE_COMBO:
       s = strstr(opt->defString, " var");
       len = strlen(opt->defString) - strlen(s);
-      opt->valString = malloc(len + 1);
+      opt->valString = (char*)malloc(len + 1);
       strncpy(opt->valString, opt->defString, len);
       opt->valString[len] = 0;
       for (s = opt->valString; *s; s++)
@@ -268,12 +268,12 @@ int option_set_by_name(char *name, char *value)
         break;
       case OPT_TYPE_STRING:
         free(opt->valString);
-        opt->valString = malloc(strlen(value) + 1);
+        opt->valString = (char*)malloc(strlen(value) + 1);
         strcpy(opt->valString, value);
         break;
       case OPT_TYPE_COMBO:
         free(opt->valString);
-        opt->valString = malloc(strlen(value) + 1);
+        opt->valString = (char*)malloc(strlen(value) + 1);
         strcpy(opt->valString, value);
         for (char *s = opt->valString; *s; s++)
           *s = tolower(*s);


### PR DESCRIPTION
Make Cfish compile cleanly on both C11 and C++11 compilers.

Changes are mainly:
Warning removals
Cast of allocated memory to its target type
stdatomic.h is not available for C++, used same API from std::atomic which is all inline
No link with libstdc++

Bench in the makefile runs slightly faster for the C++ compilation

Didn't check the change with icc / mingw.
Only gcc and clang on Fedora 28/29
