### PR TITLE
64-bit SSE2: transpose the matrices

### DIFF
--- a/src/nnue.c
+++ b/src/nnue.c
@@ -50,18 +50,29 @@ uint32_t PieceToIndex[2][16] = {
   { 0, PS_B_PAWN, PS_B_KNIGHT, PS_B_BISHOP, PS_B_ROOK, PS_B_QUEEN, 0, 0,
     0, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, 0, 0 }
 };
-
 #if defined(USE_SSE2)
 #undef USE_MMX
 #endif
 
 #if (defined(USE_SSE2) || defined(USE_MMX)) && !defined(USE_SSSE3)
+#ifdef NNUE_TRANSPOSE
+typedef uint8_t clipped_t;
+#else
 typedef int16_t clipped_t; //SSE2 and MMX have no int8 multiply.
+#endif
 typedef int16_t weight_t;
 #else
 typedef uint8_t clipped_t;
 typedef int8_t weight_t;
 #endif
+
+#if defined(USE_SSSE3) && !defined(USE_AVX2)
+//#define NNUE_TRANSPOSE
+#endif
+
+#define LOOP_4(f) f(0);f(1);f(2);f(3)
+#define LOOP_8(f) LOOP_4(f); f(4);f(5);f(6);f(7)
+#define LOOP_16(f) LOOP_8(f); f(8);f(9);f(10);f(11);f(12);f(13);f(14);f(15)
 
 // Version of the evaluation file
 static const uint32_t NnueVersion = 0x7AF32F16u;
@@ -307,9 +318,145 @@ INLINE void affine_propagate(clipped_t *input, int32_t *output, unsigned inDims,
 
 #endif
   }
+}
+#ifdef NNUE_TRANSPOSE
+union mask_t {
+    uint16_t asRegBitmask[4]; //change to 32 for AVX2
+    uint64_t asInt[1]; //change according to max int size
+};
+static_assert(FtOutDims % 64 == 0, "FtOutDims not a multiple of 64"); // input_mask is read 64 bits per. If FtOutDims is changed to be not a multiple of 64, make sure to initialize end of input_mask.
+#if defined(USE_SSE2) && defined(IS_64BIT)
+INLINE void affine_txfm(const clipped_t *in, char *out, unsigned inDims,
+    unsigned outDims, const int32_t *biases, weight_t *weights,
+    const union mask_t* input_mask, union mask_t* output_mask, 
+    bool pack8_and_calc_mask) {
+  assert(outDims == 32);
+  __m128i kZeros[4];
+  memset(kZeros, 0, 64);
+  __m128i *biases_cast = (__m128i *) biases;
+#define TMP(j) __m128i out_##j = biases_cast[j]
+  LOOP_8(TMP);
+#undef TMP
+  const uint64_t *inm_lbound = input_mask->asInt;
+  const uint64_t *inm_cast = inm_lbound;
+  const uint64_t *inm_ubound = inm_lbound + (inDims+63)/64;
+  uint64_t pos;
+  unsigned i = 0, i1; uint64_t inm_val = 0;
+  __m128i *first, *second;
+  do {
+    while (inm_val == 0 && inm_cast < inm_ubound) {
+      inm_val = *inm_cast;
+      inm_cast++;
+    }
+    if (inm_val == 0) break; 
+    pos = __builtin_ctzll(inm_val); // lsb position
+    i = pos + ((inm_cast - inm_lbound) - 1)*64; // TODO: fix 32-bit
+    inm_val &= inm_val - 1; //pop lsb
+    first  = (__m128i*)&weights[outDims * i];
+    while (inm_val == 0 && inm_cast < inm_ubound) {
+      inm_val = *inm_cast;
+      inm_cast++;
+    }
+    pos = __builtin_ctzll(inm_val); // lsb position
+    i1 = pos + ((inm_cast - inm_lbound) - 1)*64; //TODO: fix 32-bit
+    inm_val &= inm_val - 1; //pop lsb
+    __m128i mul;
+    if (i1 < inDims) {
+        mul = _mm_set1_epi32(in[i1] << 16 | in[i] );
+        second = (__m128i*)&weights[outDims * i1];
+    } else {
+        mul = _mm_set1_epi32(in[i]);
+        second = kZeros;
+    }
+    out_0 = _mm_add_epi32(out_0, _mm_madd_epi16(mul, _mm_unpacklo_epi16(first[0],second[0])));
+    out_1 = _mm_add_epi32(out_1, _mm_madd_epi16(mul, _mm_unpackhi_epi16(first[0],second[0])));
+    out_2 = _mm_add_epi32(out_2, _mm_madd_epi16(mul, _mm_unpacklo_epi16(first[1],second[1])));
+    out_3 = _mm_add_epi32(out_3, _mm_madd_epi16(mul, _mm_unpackhi_epi16(first[1],second[1])));
+    out_4 = _mm_add_epi32(out_4, _mm_madd_epi16(mul, _mm_unpacklo_epi16(first[2],second[2])));
+    out_5 = _mm_add_epi32(out_5, _mm_madd_epi16(mul, _mm_unpackhi_epi16(first[2],second[2])));
+    out_6 = _mm_add_epi32(out_6, _mm_madd_epi16(mul, _mm_unpacklo_epi16(first[3],second[3])));
+    out_7 = _mm_add_epi32(out_7, _mm_madd_epi16(mul, _mm_unpackhi_epi16(first[3],second[3])));
+  } while (true);
+  __m128i out_in16_0 = _mm_srai_epi16(_mm_packs_epi32(out_0, out_1), SHIFT);
+  __m128i out_in16_1 = _mm_srai_epi16(_mm_packs_epi32(out_2, out_3), SHIFT);
+  __m128i out_in16_2 = _mm_srai_epi16(_mm_packs_epi32(out_4, out_5), SHIFT);
+  __m128i out_in16_3 = _mm_srai_epi16(_mm_packs_epi32(out_6, out_7), SHIFT);
 
+  __m128i *out_cast = (__m128i*) out;
+  if (pack8_and_calc_mask) {
+    uint16_t *outmask_view = output_mask->asRegBitmask;
+    const __m128i k0x80s = _mm_set1_epi8(-128);
+    __m128i reg_tmp;
+    reg_tmp = _mm_subs_epi8(_mm_adds_epi8(_mm_packs_epi16(out_in16_0, out_in16_1), k0x80s), k0x80s);
+    out_cast[0] = reg_tmp;
+    outmask_view[0] = _mm_movemask_epi8(_mm_cmpgt_epi8(reg_tmp, kZeros[0]));
+    reg_tmp = _mm_subs_epi8(_mm_adds_epi8(_mm_packs_epi16(out_in16_2, out_in16_3), k0x80s), k0x80s);
+    out_cast[1] = reg_tmp;
+    outmask_view[1] = _mm_movemask_epi8(_mm_cmpgt_epi8(reg_tmp, kZeros[0]));
+  } else {
+    const __m128i k0x7f80s = _mm_set1_epi16(0x7f80);
+#define TMP(j) out_cast[j] = _mm_subs_epu16(_mm_adds_epi16(out_in16_##j, k0x7f80s), k0x7f80s);
+    LOOP_4(TMP);
+#undef TMP
+  }
+}
+INLINE void scalar_prod(int16_t *input, int32_t *output, unsigned inDims,
+    unsigned outDims, int32_t *biases, weight_t *weights)
+{
+  assert(inDims % 32 == 0);
+  assert(outDims == 1);
+#if defined(USE_SSE2)
+  const unsigned numChunks = inDims / 16;
+  __m128i *inVec = (__m128i *)input;
+#elif defined(USE_MMX)
+  const unsigned numChunks = inDims / 8;
+  __m64 *inVec = (__m64 *)input;
+
+#endif
+  
+  for (unsigned i = 0; i < outDims; ++i) {
+    unsigned offset = i * inDims;
+
+#if defined(USE_SSE2)
+    __m128i sum = _mm_setzero_si128(), sum1 = sum;
+    __m128i *row = (__m128i *)&weights[offset];
+    for (unsigned j = 0; j < numChunks; j++) {
+      __m128i product0 = _mm_madd_epi16(inVec[2 * j], row[2 * j]);
+      sum = _mm_add_epi32(sum, product0);
+      __m128i product1 = _mm_madd_epi16(inVec[2 * j + 1], row[2 * j + 1]);
+      sum1 = _mm_add_epi32(sum1, product1);
+    }
+    sum = _mm_add_epi32(sum, sum1);
+    sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xE));
+    sum = _mm_add_epi32(sum, _mm_shufflelo_epi16(sum, 0xE));
+    output[i] = _mm_cvtsi128_si32(sum) + biases[i];
+
+#elif defined(USE_MMX)
+    // adding 1 or 4 numbers per loop is slower, 2 seems optimal
+    __m64 s0 = _mm_setzero_si64(), s1 = s0;
+    __m64 *row = (__m64 *)&weights[offset];
+    for (unsigned j = 0; j < numChunks; j++) {
+      s0 = _mm_add_pi32(s0, _mm_madd_pi16(row[2 * j + 0], inVec[2 * j + 0]));
+      s1 = _mm_add_pi32(s1, _mm_madd_pi16(row[2 * j + 1], inVec[2 * j + 1]));
+    }
+    __m64 sum = _mm_add_pi32(s0, s1);
+    sum = _mm_add_pi32(sum, _mm_unpackhi_pi32(sum, sum));
+    output[i] = _mm_cvtsi64_si32(sum) + biases[i];
+
+#else
+    int32_t sum = biases[i];
+    for (unsigned j = 0; j < inDims; j++)
+      sum += weights[offset + j] * input[j];
+    output[i] = sum;
+
+#endif
+  }
 }
 
+#else
+#error "NNUE_TRANSPOSE requires USE_SSE2 and IS_64BIT for now"
+#endif
+#endif
 INLINE void clip_propagate(int32_t *input, clipped_t *output, unsigned numDims)
 {
   assert(numDims % 32 == 0);
@@ -329,7 +476,7 @@ INLINE void clip_propagate(int32_t *input, clipped_t *output, unsigned numDims)
           _mm256_packs_epi16(words0, words1), kZero), kOffsets);
   }
 
-#elif defined(USE_SSSE3)
+#elif defined(USE_SSSE3) || (defined(NNUE_TRANSPOSE) && defined(USE_SSE2))
   const unsigned numChunks = numDims / 16;
 #ifdef USE_SSE41
   const __m128i kZero = _mm_setzero_si128();
@@ -459,6 +606,7 @@ INLINE void refresh_accumulator(const Position *pos)
   activeIndices[0].size = activeIndices[1].size = 0;
   append_active_indices(pos, activeIndices);
 
+  assert(kHalfDimensions % TILE_HEIGHT == 0);
   for (unsigned c = 0; c < 2; c++) {
     for (unsigned i = 0; i < kHalfDimensions / TILE_HEIGHT; i++) {
 #if defined(USE_SSE2) || defined(USE_MMX)
@@ -612,7 +760,7 @@ INLINE bool update_accumulator_if_possible(const Position *pos)
 }
 
 // Convert input features
-INLINE void transform(const Position *pos, clipped_t *output)
+INLINE void transform(const Position *pos, clipped_t *output, union mask_t* out_mask_buf)
 {
   if (!update_accumulator_if_possible(pos))
     refresh_accumulator(pos);
@@ -627,10 +775,13 @@ INLINE void transform(const Position *pos, clipped_t *output)
   const unsigned numChunks = kHalfDimensions / 16;
   const __m128i kZero = _mm_setzero_si128();
 
-#elif defined(USE_SSSE3)
+#elif defined(USE_SSSE3) || (defined(USE_SSE2) && defined(NNUE_TRANSPOSE))
   const unsigned numChunks = kHalfDimensions / 16;
   const __m128i k0x80s = _mm_set1_epi8(-128);
-
+  const __m128i kZero = _mm_setzero_si128();
+#ifdef NNUE_TRANSPOSE
+  uint16_t* out_mask = out_mask_buf->asRegBitmask;
+#endif
 #elif defined(USE_SSE2)
   const unsigned numChunks = kHalfDimensions / 8;
   const __m128i k0x7f80 = _mm_set1_epi16(0x7f80);
@@ -662,17 +813,20 @@ INLINE void transform(const Position *pos, clipped_t *output)
           _mm256_packs_epi16(sum0, sum1), kZero), 0xd8);
     }
 
-#elif defined(USE_SSSE3)
+#elif defined(USE_SSSE3) || (defined(NNUE_TRANSPOSE) && defined(USE_SSE2))
     __m128i *out = (__m128i *)&output[offset];
     for (unsigned i = 0; i < numChunks; i++) {
       __m128i sum0 = ((__m128i *)(*accumulation)[perspectives[p]])[i * 2 + 0];
       __m128i sum1 = ((__m128i *)(*accumulation)[perspectives[p]])[i * 2 + 1];
       __m128i packedbytes = _mm_packs_epi16(sum0, sum1);
+      __m128i outres; 
 #if defined(USE_SSE41)
-      out[i] = _mm_max_epi8(packedbytes, kZero);
+      outres = _mm_max_epi8(packedbytes, kZero);
 #else
-      out[i] = _mm_subs_epi8(_mm_adds_epi8(packedbytes, k0x80s), k0x80s);
+      outres = _mm_subs_epi8(_mm_adds_epi8(packedbytes, k0x80s), k0x80s);
 #endif
+      out[i] = outres;
+      *out_mask++ = _mm_movemask_epi8(_mm_cmpgt_epi8(outres, kZero));
     }
 
 #elif defined(USE_SSE2)
@@ -714,11 +868,13 @@ struct NetData {
   clipped_t hidden1_clipped[32];
   clipped_t hidden2_clipped[32];
 };
-
 // Evaluation function
 Value nnue_evaluate(const Position *pos)
 {
   int32_t out_value;
+  alignas(8) union mask_t input_mask[FtOutDims / 64 + 1];
+  alignas(8) union mask_t hidden1_mask[1];
+  //alignas(8) char hidden2_mask[16];
 #if defined(__GNUC__ ) && (__GNUC__ < 9) && defined(_WIN32) && !defined(__clang__) && !defined(__INTEL_COMPILER)
   // work around a bug in old gcc on Windows
   uint8_t buf[sizeof(struct NetData) + 63];
@@ -729,7 +885,8 @@ Value nnue_evaluate(const Position *pos)
 #define B(x) (buf.x)
 #endif
 
-  transform(pos, B(input));
+  transform(pos, B(input), input_mask);
+#ifndef NNUE_TRANSPOSE
   affine_propagate(B(input), B(hidden1_values), FtOutDims, 32,
       hidden1_biases, hidden1_weights);
   clip_propagate(B(hidden1_values), B(hidden1_clipped), 32);
@@ -738,7 +895,18 @@ Value nnue_evaluate(const Position *pos)
   clip_propagate(B(hidden2_values), B(hidden2_clipped), 32);
   affine_propagate(B(hidden2_clipped), &out_value, 32, 1, output_biases,
       output_weights);
-
+#else
+  alignas(64) int16_t hidden2_out[32];
+#ifdef IS_64BIT
+  (*(union mask_t*)hidden1_mask).asInt[0] = 0ULL; // initialize, because final 32 bits won't be written but will be read
+#endif
+  affine_txfm(B(input), B(hidden1_clipped), FtOutDims, 32,
+      hidden1_biases, hidden1_weights, input_mask, hidden1_mask, true);
+  affine_txfm(B(hidden1_clipped), hidden2_out, 32, 32,
+      hidden2_biases, hidden2_weights, hidden1_mask, NULL, false);
+  scalar_prod(hidden2_out, &out_value, 32, 1, output_biases,
+      output_weights);
+#endif
 #if defined(USE_MMX)
   _mm_empty();
 #endif
@@ -746,10 +914,20 @@ Value nnue_evaluate(const Position *pos)
   return out_value / FV_SCALE;
 }
 
-bool read_weights(weight_t *output_buf, unsigned count, FILE *F)
+bool read_weights(weight_t *output_buf, unsigned width, unsigned height,
+    FILE *F)
 {
-  for (unsigned i = 0; i < count; i++)
-    output_buf[i] = (weight_t)(int8_t)fgetc(F);
+  for (unsigned i = 0; i < height; i++) {
+    for (unsigned j = 0; j < width; j++) {
+      int8_t tmp = (int8_t)fgetc(F);
+#ifndef NNUE_TRANSPOSE
+      output_buf[i * width + j] =
+#else
+      output_buf[j * height + i] =
+#endif
+        (weight_t)tmp;
+    }
+  }
   return true;
 }
 
@@ -778,12 +956,11 @@ bool load_eval_file(const char *evalFile)
   hash = read_uint32_t(F);
   if (hash != 0x63337156) return false;
   fread(hidden1_biases, sizeof(int32_t), 32, F);
-  read_weights(hidden1_weights, 32 * 512, F);
+  read_weights(hidden1_weights, 512, 32, F);
   fread(hidden2_biases, sizeof(int32_t), 32, F);
-  read_weights(hidden2_weights, 32 * 32 , F);
+  read_weights(hidden2_weights, 32 , 32 , F);
   fread(output_biases, sizeof(int32_t), 1 , F);
-  read_weights(output_weights, 1  * 32 , F);
-
+  read_weights(output_weights, 32, 1 , F);
   return true;
 //  return feof(F);
 }

--- a/src/uci.c
+++ b/src/uci.c
@@ -338,6 +338,12 @@ void uci_loop(int argc, char **argv)
 
     // Additional custom non-UCI commands, useful for debugging
     else if (strcmp(token, "bench") == 0)     benchmark(&pos, str);
+#ifdef NNUE
+    else if (strcmp(token, "evalnn") == 0)    {
+      nnue_init(); 
+      printf("NNUE eval = %d\n", nnue_evaluate(&pos));
+    }
+#endif
     else if (strcmp(token, "d") == 0)         print_pos(&pos);
     else if (strcmp(token, "perft") == 0) {
       sprintf(str_buf, "%d %d %d current perft", option_value(OPT_HASH),


### PR DESCRIPTION
64-bit SSE2: transpose the matrices
To activate:
CFLAGS='-DNNUE_TRANSPOSE -fno-strict-aliasing' make ARCH=x86-64 ...
-fno-strict-aliasing is required, and GCC specific intrinsic is used.
At least 5% speed gain for me. My measurements do not seem to be reliable, as I see larger gains under MSYS2 shell. (yes, I tried using a stopwatch, it seems to report correct numbers if redirecting stdout to a file, at least).
Sorry for the state of this PR. I am sick of chasing a bug due to strict aliasing "optimization". It was invented by wreckers anyway, so I don't care and just disable it. If you want, I'll clean it up in a few days.

Exploits activation sparsity discovered using @hxim 's "Stockfish Evaluation Guide" tool.
The idea is described at https://github.com/official-stockfish/Stockfish/issues/2908 . @nodchip you, or maybe other shogi devs could be interested.