### PR TITLE
Fix build with old glibc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -447,7 +447,7 @@ endif
 
 ifneq ($(COMP),mingw)
 ifeq ($(KERNEL),$(filter $(KERNEL),Linux Darwin Haiku))
-	CFLAGS += -D_DEFAULT_SOURCE
+	CFLAGS += -D_DEFAULT_SOURCE -D_BSD_SOURCE
 endif
 endif
 


### PR DESCRIPTION
Define _BSD_SOURCE as well, needed for glibc 2.19 and below