### PR TITLE
Fix type errors in nnue.c

### DIFF
--- a/src/nnue.c
+++ b/src/nnue.c
@@ -553,14 +553,14 @@ INLINE bool next_idx(unsigned *idx, unsigned *offset, uint64_t *v,
 }
 
 #ifdef USE_NEON
-INLINE void neon_movemask(uint8_t *outMask, uint8x16_t out)
+INLINE void neon_movemask(uint8_t *outMask, int8x16_t out)
 {
   const uint8_t __attribute__((aligned(16))) powers[16] =
     { 1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128 };
   const uint8x16_t kPowers = vld1q_u8(powers);
   const uint8x16_t kZero = { 0 };
 
-  uint8x16_t gt = vcgtq_s8(out, kZero);
+ int8x16_t gt = vcgtq_s8(out, kZero);
   uint64x2_t mask = vpaddlq_u32(vpaddlq_u16(vpaddlq_u8(vandq_u8(gt, kPowers))));
   vst1q_lane_u8(outMask, (uint8x16_t)mask, 0);
   vst1q_lane_u8(outMask + 1, (uint8x16_t)mask, 8);


### PR DESCRIPTION
According to the [ARM User Guide](https://developer.arm.com/documentation/dui0472/m/using-neon-support/neon-intrinsics-for-comparison) , the args for `vcgtq_s8` should be `int8x16_t` . The original code throws type errors with gcc 10.2 on armv8 / raspberry pi 4. This PR compiles without warnings or errors, is slightly faster than the non-TRANSPOSE version, and passes sanity checks on benchmarks.