### PR TITLE
Fix type error in neon code

### DIFF
--- a/src/nnue.c
+++ b/src/nnue.c
@@ -154,7 +154,7 @@ typedef uint16_t mask_t;
 #define vec_add_16(a,b) vaddq_s16(a,b)
 #define vec_sub_16(a,b) vsubq_s16(a,b)
 #define vec_packs(a,b) vcombine_s8(vqmovn_s16(a),vqmovn_s16(b))
-#define vec_mask_pos(a) neon_movemask(vcgtq_s8(a,vdupq_n_u8(0)))
+#define vec_mask_pos(a) neon_movemask(vcgtq_s8(a,vdupq_n_s8(0)))
 #ifdef IS_64BIT
 #define NUM_REGS 16
 #else


### PR DESCRIPTION
gcc 10.2 on armv8 throws a type error again.