### PR TITLE
nnue=no compilation bug fix

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -53,7 +53,9 @@ int main(int argc, char **argv)
   options_free();
   tt_free();
   pb_free();
+  #ifdef NNUE
   nnue_free();
+  #endif
 
   return 0;
 }


### PR DESCRIPTION
nnue=no compilation bug fix in main.c:

main.c: In function 'main':
main.c:59:1: warning: implicit declaration of function 'nnue_free' [-Wimplicit-function-declaration]
   59 | nnue_free();
      | ^~~~~~~~~

C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: main.o:main.c:(.text.startup+0x67): undefined reference to `nnue_free'
collect2.exe: error: ld returned 1 exit status

