### PR TITLE
BMI version of attacks_bb_rook added; fix silly SQUARE_FLIP def

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -277,7 +277,7 @@ extern Value PieceValue[2][16];
 
 extern uint32_t NonPawnPieceValue[16];
 
-#define SQUARE_FLIP(s) (sq ^ 0x38)
+#define SQUARE_FLIP(sq) ((sq) ^ 0x38)
 
 #define mate_in(ply) ((Value)(VALUE_MATE - (ply)))
 #define mated_in(ply) ((Value)(-VALUE_MATE + (ply)))


### PR DESCRIPTION
Alternative BMI version of attacks_bb_rook is added to my avx2_bitboard code, which will be activated with -mbmi or -march options.